### PR TITLE
Progressive, profile-neutral help and bounded capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,10 +115,36 @@ The agent exposes its host's operations as MCP tools to your LLM via the hub:
 | `sentinel_read` | Read a file's contents, with optional line-range slicing |
 | `sentinel_list` | Structured directory listing (name, type, size, mtime) |
 | `sentinel_search` | Recursive content search with regex and glob filters |
-| `sentinel_capabilities` | Returns the host's allowlist + service definitions |
-| `sentinel_help` | A short summary of the agent plus counts of allowed commands, services, and playbooks |
+| `sentinel_capabilities` | Host policy/capabilities; optional bounded summary projection |
+| `sentinel_help` | Rich orientation/help; optional topic/path/single-playbook projections |
 | `sentinel_state` | Internal agent state, for debugging |
 | `sentinel_ping` | Cheap connectivity check |
+
+### Progressive introspection (agent operation contract)
+
+The agent-side `help` and `capabilities` operations also support optional
+narrow-response selectors. A Hub/MCP profile may expose these fields through
+whatever model-facing tool shape it uses; the selectors are backend-operation
+semantics and do not depend on full vs compact tool names.
+
+- `help({"topic":"index"})` — small topic + paged playbook index.
+- `help({"topic":"security"})` — one broad help section.
+- `help({"path":"security_model.permission_errors"})` — one exact leaf from
+  the existing help tree.
+- `help({"playbook":"update_sentinelx_code"})` — one playbook only; optional
+  `path`, `offset`, and `limit` can select/page a subfield such as `steps`.
+- `capabilities({"detail":"summary"})` — host/operation/limit metadata and
+  policy counts without command/service/location/playbook bodies.
+
+Progressive help/playbook responses normalize explicit full-profile
+`sentinel_*` references to `op:<name>` canonical operation hints so the same
+guidance can be routed through compact or full presentation without teaching a
+playbook two sets of MCP tool names.
+
+For compatibility, empty `help({})` and `capabilities({})` requests retain the
+legacy full responses. A Hub that wants compact-first behavior should map its
+compact help/capabilities branches to the narrow selectors rather than changing
+the agent's legacy empty-payload semantics.
 
 `sentinel_read`, `sentinel_list`, and `sentinel_search` are **read-only
 filesystem primitives**. `sentinel_edit` and the mutating primitives

--- a/src/sentinelx_core/handlers/basic.py
+++ b/src/sentinelx_core/handlers/basic.py
@@ -9,6 +9,11 @@ from typing import Any
 
 from sentinelx_core import AGENT_VERSION
 from sentinelx_core import platform_guidance as _pg
+from sentinelx_core.handlers.progressive_help import (
+    capabilities_detail,
+    select_help_response,
+    summarize_capabilities,
+)
 from sentinelx_core.policy import Policy
 
 
@@ -50,6 +55,7 @@ def make_capabilities_handler(policy: Policy, config_path=None):
         This is the dynamic equivalent of legacy SentinelX's GET /capabilities.
         Output is shaped to be friendly for an LLM tool: lists, dicts, no fluff.
         """
+        detail = capabilities_detail(payload)
         locations = {
             label: {"path": spec.path, "description": spec.description}
             for label, spec in policy.locations.items()
@@ -63,7 +69,7 @@ def make_capabilities_handler(policy: Policy, config_path=None):
                 "path": str(config_path),
                 "description": "The agent's active config.yaml.",
             }
-        return {
+        result = {
             "agent": "sentinelx-cloud-core",
             "version": AGENT_VERSION,
             "host": {
@@ -157,6 +163,9 @@ def make_capabilities_handler(policy: Policy, config_path=None):
                 "max_search_results": policy.file_ops_max_search_results,
             },
         }
+        if detail == "summary":
+            return summarize_capabilities(result)
+        return result
 
     return handle_capabilities
 
@@ -168,7 +177,7 @@ def make_help_handler(policy: Policy):
         example tasks and reference links."""
         paths = policy.file_ops_paths
         writable = [p for p in paths if getattr(p, "access", "r") == "rw"]
-        return {
+        full = {
             "agent": "sentinelx-cloud-core",
             "version": AGENT_VERSION,
             "host_label": policy.hostname_label,
@@ -308,6 +317,7 @@ def make_help_handler(policy: Policy):
                 "origin_story": "How I Accidentally Built an MCP Server for My Linux Servers: https://carolusx.medium.com/how-i-accidentally-built-an-mcp-server-for-my-linux-servers-11a288feb899",
             },
         }
+        return select_help_response(payload, full, policy.playbooks)
     return handle_help
 
 

--- a/src/sentinelx_core/handlers/progressive_help.py
+++ b/src/sentinelx_core/handlers/progressive_help.py
@@ -1,0 +1,367 @@
+"""Small, progressive projections for SentinelX help and capabilities.
+
+Legacy empty-payload responses stay unchanged. Optional selectors let a Hub
+request only the guidance/policy summary an LLM needs and keep returned
+instructions neutral across full and compact MCP presentations.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from typing import Any
+
+from sentinelx_core.executor import HandlerError
+
+_PAGE_DEFAULT = 50
+_PAGE_MAX = 100
+_TOOL_RE = re.compile(r"\bsentinel_([a-z][a-z0-9_]*)\b")
+
+_TOPICS: dict[str, tuple[str, str]] = {
+    "getting_started": ("getting_started", "minimal first-use guidance"),
+    "security": ("security_model", "security and permission model"),
+    "operations": ("navigation", "operation/navigation map"),
+    "operating_notes": ("operating_notes", "general operating notes"),
+    "access": ("extending_access", "how to extend configured access"),
+    "hosts": ("managing_hosts", "host enrollment, update, and targeting"),
+    "playbooks": ("playbooks", "paged playbook-name index"),
+    "policy": ("policy", "policy summary counts"),
+    "examples": ("examples", "example task prompts"),
+    "resources": ("resources", "project/dashboard/contact resources"),
+    "about": ("about", "project/creator information"),
+}
+
+
+def _query(op: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+    return {"backend_operation": op, "payload": dict(payload)}
+
+
+def _string(payload: Mapping[str, Any], key: str) -> str | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise HandlerError("invalid_payload", f"'{key}' must be a non-empty string")
+    return value.strip()
+
+
+def _integer(
+    payload: Mapping[str, Any], key: str, *, default: int, minimum: int, maximum: int | None = None
+) -> int:
+    value = payload.get(key, default)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise HandlerError("invalid_payload", f"'{key}' must be an integer")
+    if value < minimum or (maximum is not None and value > maximum):
+        suffix = f"..{maximum}" if maximum is not None else "+"
+        raise HandlerError("invalid_payload", f"'{key}' must be in range {minimum}{suffix}")
+    return value
+
+
+def _page(values: list[Any], payload: Mapping[str, Any]) -> tuple[list[Any], dict[str, Any]]:
+    offset = _integer(payload, "offset", default=0, minimum=0)
+    limit = _integer(payload, "limit", default=_PAGE_DEFAULT, minimum=1, maximum=_PAGE_MAX)
+    items = values[offset : offset + limit]
+    next_offset = offset + len(items)
+    if next_offset >= len(values):
+        next_offset = None
+    return items, {
+        "total": len(values),
+        "offset": offset,
+        "limit": limit,
+        "next_offset": next_offset,
+        "truncated": next_offset is not None,
+    }
+
+
+def _lookup(root: Any, path: str) -> Any:
+    parts = path.split(".")
+    if any(not part for part in parts):
+        raise HandlerError("invalid_payload", "'path' must be dot-separated object keys")
+    node = root
+    walked: list[str] = []
+    for part in parts:
+        if not isinstance(node, Mapping):
+            raise HandlerError(
+                "invalid_payload",
+                f"help path cannot descend through non-object at {'.'.join(walked) or '<root>'}",
+            )
+        if part not in node:
+            names = sorted(str(key) for key in node)[:50]
+            raise HandlerError(
+                "invalid_payload",
+                f"unknown help path component: {part}",
+                details={
+                    "path_prefix": ".".join(walked),
+                    "available_keys": names,
+                    "available_key_count": len(node),
+                    "available_keys_truncated": len(node) > len(names),
+                },
+            )
+        node = node[part]
+        walked.append(part)
+    return node
+
+
+def _neutralize(value: Any) -> tuple[Any, dict[str, str]]:
+    """Copy JSON-like guidance and replace full-profile sentinel_* references."""
+    references: dict[str, str] = {}
+
+    def visit(node: Any) -> Any:
+        if isinstance(node, str):
+
+            def replace(match: re.Match[str]) -> str:
+                source = match.group(0)
+                operation = match.group(1)
+                references[source] = operation
+                return f"op:{operation}"
+
+            return _TOOL_RE.sub(replace, node)
+        if isinstance(node, Mapping):
+            return {key: visit(item) for key, item in node.items()}
+        if isinstance(node, list):
+            return [visit(item) for item in node]
+        if isinstance(node, tuple):
+            return tuple(visit(item) for item in node)
+        return node
+
+    return visit(value), dict(sorted(references.items()))
+
+
+def _project_selected(value: Any, payload: Mapping[str, Any]) -> tuple[Any, dict[str, Any] | None]:
+    has_page = "offset" in payload or "limit" in payload
+    if isinstance(value, (list, tuple)):
+        return _page(list(value), payload)
+    if has_page:
+        raise HandlerError("invalid_payload", "offset/limit require a list-valued path")
+    return value, None
+
+
+def _presentation(refs: Mapping[str, str]) -> dict[str, Any] | None:
+    if not refs:
+        return None
+    # Design note: op:<name> is deliberately a small agent-side convention,
+    # not a claim that every Hub/profile must render guidance this way. It keeps
+    # newly-scoped responses usable when the same backend operation is exposed
+    # as a full sentinel_* tool or as a compact multiplexed branch. A Hub that
+    # prefers to translate presentation names itself can do so; this normalization
+    # is confined to the new progressive responses and does not rewrite policy.
+    return {
+        "tool_reference_map": dict(refs),
+        "note": (
+            "Progressive guidance rewrites full-profile sentinel_* names as op:<name>. "
+            "Route op:<name> through the active Hub profile."
+        ),
+    }
+
+
+def select_help_response(
+    payload: Mapping[str, Any], full: Mapping[str, Any], playbooks: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Return legacy full help or a narrow topic/path/playbook projection."""
+    unknown = sorted(set(payload) - {"topic", "path", "playbook", "offset", "limit"})
+    if unknown:
+        raise HandlerError("invalid_payload", f"unknown help field(s): {', '.join(unknown)}")
+
+    topic = _string(payload, "topic")
+    path = _string(payload, "path")
+    playbook = _string(payload, "playbook")
+    has_page = "offset" in payload or "limit" in payload
+    if topic and (path or playbook):
+        raise HandlerError("invalid_payload", "topic is mutually exclusive with path/playbook")
+
+    if topic is None and path is None and playbook is None:
+        if has_page:
+            raise HandlerError(
+                "invalid_payload", "offset/limit require an index or list-valued path"
+            )
+        return dict(full)
+
+    base = {
+        "agent": full.get("agent"),
+        "version": full.get("version"),
+        "host_label": full.get("host_label"),
+    }
+
+    if playbook is not None:
+        definition = playbooks.get(playbook)
+        if definition is None:
+            names, page = _page(sorted(playbooks), {})
+            raise HandlerError(
+                "invalid_payload",
+                f"unknown playbook: {playbook}",
+                details={"available_playbooks": {"names": names, **page}},
+            )
+        if path is None:
+            if has_page:
+                raise HandlerError("invalid_payload", "offset/limit require a playbook subpath")
+            value, refs = _neutralize(definition)
+            result = {**base, "playbook": playbook, "definition": value}
+        else:
+            selected = _lookup(definition, path)
+            selected, page = _project_selected(selected, payload)
+            value, refs = _neutralize(selected)
+            result = {**base, "playbook": playbook, "path": path, "value": value}
+            if page is not None:
+                result["pagination"] = page
+                if page["next_offset"] is not None:
+                    result["next"] = _query(
+                        "help",
+                        {
+                            "playbook": playbook,
+                            "path": path,
+                            "offset": page["next_offset"],
+                            "limit": page["limit"],
+                        },
+                    )
+        presentation = _presentation(refs)
+        if presentation:
+            result["presentation"] = presentation
+        return result
+
+    if path is not None:
+        selected = _lookup(full, path)
+        selected, page = _project_selected(selected, payload)
+        value, refs = _neutralize(selected)
+        result = {**base, "path": path, "value": value}
+        if page is not None:
+            result["pagination"] = page
+            if page["next_offset"] is not None:
+                result["next"] = _query(
+                    "help",
+                    {"path": path, "offset": page["next_offset"], "limit": page["limit"]},
+                )
+        presentation = _presentation(refs)
+        if presentation:
+            result["presentation"] = presentation
+        return result
+
+    if topic is None:
+        raise HandlerError("invalid_payload", "topic is required")
+    topic = topic.lower()
+    if topic == "all":
+        if has_page:
+            raise HandlerError("invalid_payload", "topic=all does not accept offset/limit")
+        return dict(full)
+    if topic == "index":
+        names, page = _page(sorted(playbooks), payload)
+        return {
+            **base,
+            "summary": full.get("summary"),
+            "topics": {name: description for name, (_key, description) in _TOPICS.items()},
+            "path_examples": [
+                "security_model.permission_errors",
+                "security_model.allowlist_errors",
+                "navigation.exec",
+                "managing_hosts.targeting",
+            ],
+            "playbooks": {"names": names, **page},
+            "next": {
+                "topic": _query("help", {"topic": "security"}),
+                "path": _query("help", {"path": "security_model.permission_errors"}),
+                "playbook": _query("help", {"playbook": "<name>"}),
+                "next_page": (
+                    _query(
+                        "help",
+                        {"topic": "index", "offset": page["next_offset"], "limit": page["limit"]},
+                    )
+                    if page["next_offset"] is not None
+                    else None
+                ),
+                "full": _query("help", {"topic": "all"}),
+            },
+        }
+
+    entry = _TOPICS.get(topic)
+    if entry is None:
+        raise HandlerError(
+            "invalid_payload",
+            f"unknown help topic: {topic}",
+            details={"available_topics": ["index", *_TOPICS, "all"]},
+        )
+    key, _description = entry
+    if topic == "playbooks":
+        names, page = _page(sorted(playbooks), payload)
+        return {
+            **base,
+            "topic": topic,
+            "playbooks": {"names": names, **page},
+            "next": {
+                "playbook": _query("help", {"playbook": "<name>"}),
+                "next_page": (
+                    _query(
+                        "help",
+                        {
+                            "topic": "playbooks",
+                            "offset": page["next_offset"],
+                            "limit": page["limit"],
+                        },
+                    )
+                    if page["next_offset"] is not None
+                    else None
+                ),
+            },
+        }
+    if has_page:
+        raise HandlerError("invalid_payload", "offset/limit are valid only for paged lists")
+    value, refs = _neutralize(full.get(key))
+    result = {**base, "topic": topic, key: value}
+    presentation = _presentation(refs)
+    if presentation:
+        result["presentation"] = presentation
+    return result
+
+
+def capabilities_detail(payload: Mapping[str, Any]) -> str:
+    unknown = sorted(set(payload) - {"detail"})
+    if unknown:
+        raise HandlerError(
+            "invalid_payload", f"unknown capabilities field(s): {', '.join(unknown)}"
+        )
+    raw = payload.get("detail", "full")
+    if not isinstance(raw, str) or raw.strip().lower() not in {"full", "summary"}:
+        raise HandlerError("invalid_payload", "detail must be 'full' or 'summary'")
+    return raw.strip().lower()
+
+
+def summarize_capabilities(full: Mapping[str, Any]) -> dict[str, Any]:
+    """Return discovery metadata without policy values or playbook bodies."""
+    commands = full.get("allowed_commands") or []
+    services = full.get("services") or {}
+    locations = full.get("locations") or {}
+    playbooks = full.get("playbooks") or {}
+    fetch = full.get("fetch_policy") or {}
+    file_ops = full.get("file_ops") or {}
+    paths = file_ops.get("paths") or []
+    writable = file_ops.get("writable_paths") or []
+    return {
+        "agent": full.get("agent"),
+        "version": full.get("version"),
+        "host": full.get("host"),
+        "ops_supported": full.get("ops_supported"),
+        "limits": full.get("limits"),
+        "file_ops_limits": {
+            "max_read_bytes": file_ops.get("max_read_bytes"),
+            "max_list_entries": file_ops.get("max_list_entries"),
+            "max_search_results": file_ops.get("max_search_results"),
+        },
+        "policy_summary": {
+            "allowed_commands": len(commands),
+            "services": len(services),
+            "locations": len(locations),
+            "playbooks": len(playbooks),
+            "file_ops_paths": len(paths),
+            "writable_paths": len(writable),
+            "trusted_fetch_hosts": len(fetch.get("trusted_fetch_hosts") or []),
+        },
+        "query_contract": {
+            "help": ["topic", "path", "playbook", "offset", "limit"],
+            "capabilities_detail": ["summary", "full"],
+            "max_page_limit": _PAGE_MAX,
+            "legacy_empty_payload": "full",
+        },
+        "next": {
+            "help_index": _query("help", {"topic": "index"}),
+            "playbook": _query("help", {"playbook": "<name>"}),
+            "full_capabilities": _query("capabilities", {"detail": "full"}),
+        },
+    }

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -19,11 +19,13 @@ async def test_ping() -> None:
 
 @pytest.mark.asyncio
 async def test_capabilities_reflects_policy() -> None:
-    p = Policy.from_dict({
-        "agent": {"hostname_label": "orion"},
-        "allowed_commands": ["ls", "cat"],
-        "services": {"nginx": {"actions": ["status", "restart"]}},
-    })
+    p = Policy.from_dict(
+        {
+            "agent": {"hostname_label": "orion"},
+            "allowed_commands": ["ls", "cat"],
+            "services": {"nginx": {"actions": ["status", "restart"]}},
+        }
+    )
     handlers = build_registry(policy=p)
     result = await handlers["capabilities"]({})
     assert result["host"]["label"] == "orion"
@@ -48,13 +50,15 @@ async def test_capabilities_exposes_fetch_policy_defaults() -> None:
 async def test_capabilities_exposes_configured_trusted_hosts() -> None:
     """When the operator configures trusted_fetch_hosts, capabilities
     surfaces them so the LLM knows where it can fetch from."""
-    p = Policy.from_dict({
-        "allowed_commands": ["ls"],
-        "security": {
-            "trusted_fetch_hosts": ["drop.pensa.ar", "get.sentinelx.app"],
-            "file_url_timeout_seconds": 20,
-        },
-    })
+    p = Policy.from_dict(
+        {
+            "allowed_commands": ["ls"],
+            "security": {
+                "trusted_fetch_hosts": ["drop.pensa.ar", "get.sentinelx.app"],
+                "file_url_timeout_seconds": 20,
+            },
+        }
+    )
     handlers = build_registry(policy=p)
     result = await handlers["capabilities"]({})
     fp = result["fetch_policy"]
@@ -117,7 +121,6 @@ async def test_state_returns_host_info() -> None:
     assert "now_utc" in result
 
 
-
 @pytest.mark.asyncio
 async def test_ops_supported_matches_registry() -> None:
     """`ops_supported` in capabilities is a hand-maintained list; it
@@ -134,12 +137,10 @@ async def test_ops_supported_matches_registry() -> None:
     missing_from_caps = registered - advertised
     phantom_in_caps = advertised - registered
     assert not missing_from_caps, (
-        f"ops registered but not advertised in capabilities: "
-        f"{sorted(missing_from_caps)}"
+        f"ops registered but not advertised in capabilities: {sorted(missing_from_caps)}"
     )
     assert not phantom_in_caps, (
-        f"ops advertised in capabilities but not registered: "
-        f"{sorted(phantom_in_caps)}"
+        f"ops advertised in capabilities but not registered: {sorted(phantom_in_caps)}"
     )
 
 
@@ -150,6 +151,263 @@ async def test_capabilities_advertises_mutating_ops() -> None:
     handlers = build_registry(policy=Policy.empty())
     result = await handlers["capabilities"]({})
     for op in ("move", "copy", "delete", "chmod", "chown"):
-        assert op in result["ops_supported"], (
-            f"{op!r} missing from ops_supported"
-        )
+        assert op in result["ops_supported"], f"{op!r} missing from ops_supported"
+
+
+@pytest.mark.asyncio
+async def test_help_progressive_index_is_bounded() -> None:
+    p = Policy.from_dict(
+        {
+            "allowed_commands": ["ls", "cat"],
+            "playbooks": {
+                "demo": {
+                    "description": "Demo workflow",
+                    "steps": ["do one thing", "do another thing"],
+                }
+            },
+        }
+    )
+    handlers = build_registry(policy=p)
+    result = await handlers["help"]({"topic": "index"})
+    assert "topics" in result
+    assert "security" in result["topics"]
+    assert result["playbooks"]["names"] == ["demo"]
+    assert result["playbooks"]["total"] == 1
+    assert result["playbooks"]["truncated"] is False
+    assert result["next"]["topic"] == {
+        "backend_operation": "help",
+        "payload": {"topic": "security"},
+    }
+    assert "security_model" not in result
+    assert "navigation" not in result
+    assert "resources" not in result
+
+
+@pytest.mark.asyncio
+async def test_help_progressive_index_paginates_large_playbook_sets() -> None:
+    p = Policy.from_dict(
+        {"playbooks": {f"playbook_{i:04d}": {"description": f"workflow {i}"} for i in range(250)}}
+    )
+    handlers = build_registry(policy=p)
+    first = await handlers["help"]({"topic": "index"})
+    assert len(first["playbooks"]["names"]) == 50
+    assert first["playbooks"]["total"] == 250
+    assert first["playbooks"]["next_offset"] == 50
+    assert first["playbooks"]["truncated"] is True
+    assert first["next"]["next_page"] == {
+        "backend_operation": "help",
+        "payload": {"topic": "index", "offset": 50, "limit": 50},
+    }
+
+    second = await handlers["help"]({"topic": "playbooks", "offset": 50, "limit": 25})
+    assert second["playbooks"]["names"][0] == "playbook_0050"
+    assert len(second["playbooks"]["names"]) == 25
+    assert second["playbooks"]["next_offset"] == 75
+    assert second["next"]["next_page"] == {
+        "backend_operation": "help",
+        "payload": {"topic": "playbooks", "offset": 75, "limit": 25},
+    }
+
+
+@pytest.mark.asyncio
+async def test_help_progressive_topic_returns_only_requested_section() -> None:
+    handlers = build_registry(policy=Policy.empty())
+    result = await handlers["help"]({"topic": "security"})
+    assert result["topic"] == "security"
+    assert "security_model" in result
+    assert "navigation" not in result
+    assert "resources" not in result
+
+
+@pytest.mark.asyncio
+async def test_help_progressive_single_playbook_lookup_extracts_surface_hints() -> None:
+    p = Policy.from_dict(
+        {
+            "playbooks": {
+                "demo": {
+                    "description": "Demo workflow",
+                    "steps": [
+                        "Inspect with sentinel_read, then run sentinel_exec if needed.",
+                        "Verify with sentinel_capabilities.",
+                    ],
+                }
+            }
+        }
+    )
+    handlers = build_registry(policy=p)
+    result = await handlers["help"]({"playbook": "demo"})
+    assert result["playbook"] == "demo"
+    assert result["definition"]["steps"][0].startswith("Inspect with op:read")
+    assert result["presentation"]["tool_reference_map"] == {
+        "sentinel_capabilities": "capabilities",
+        "sentinel_exec": "exec",
+        "sentinel_read": "read",
+    }
+
+
+@pytest.mark.asyncio
+async def test_progressive_playbook_is_neutral_but_legacy_capabilities_keep_source_text() -> None:
+    p = Policy.from_dict(
+        {"playbooks": {"demo": {"steps": ["Run sentinel_exec then sentinel_service."]}}}
+    )
+    handlers = build_registry(policy=p)
+    narrow = await handlers["help"]({"playbook": "demo"})
+    full = await handlers["capabilities"]({})
+    assert narrow["definition"]["steps"] == ["Run op:exec then op:service."]
+    assert full["playbooks"]["demo"]["steps"] == ["Run sentinel_exec then sentinel_service."]
+
+
+@pytest.mark.asyncio
+async def test_help_empty_payload_preserves_legacy_full_response() -> None:
+    handlers = build_registry(policy=Policy.empty())
+    result = await handlers["help"]({})
+    assert "security_model" in result
+    assert "navigation" in result
+    assert "resources" in result
+    assert "introspection" not in result
+
+
+@pytest.mark.asyncio
+async def test_help_dotted_path_returns_exact_leaf() -> None:
+    handlers = build_registry(policy=Policy.empty())
+    result = await handlers["help"]({"path": "security_model.permission_errors"})
+    assert result["path"] == "security_model.permission_errors"
+    assert isinstance(result["value"], str)
+    assert "permission_denied" in result["value"]
+    assert "navigation" not in result
+
+
+@pytest.mark.asyncio
+async def test_help_playbook_subpath_can_page_steps() -> None:
+    p = Policy.from_dict(
+        {
+            "playbooks": {
+                "demo": {
+                    "description": "Demo",
+                    "steps": [f"step {i} uses sentinel_exec" for i in range(12)],
+                    "notes": ["note"],
+                }
+            }
+        }
+    )
+    handlers = build_registry(policy=p)
+    result = await handlers["help"]({"playbook": "demo", "path": "steps", "offset": 3, "limit": 4})
+    assert result["value"] == [
+        "step 3 uses op:exec",
+        "step 4 uses op:exec",
+        "step 5 uses op:exec",
+        "step 6 uses op:exec",
+    ]
+    assert result["pagination"]["next_offset"] == 7
+    assert result["presentation"]["tool_reference_map"] == {"sentinel_exec": "exec"}
+    assert result["next"] == {
+        "backend_operation": "help",
+        "payload": {"playbook": "demo", "path": "steps", "offset": 7, "limit": 4},
+    }
+
+
+@pytest.mark.asyncio
+async def test_help_dotted_path_rejects_unknown_and_non_mapping_descent() -> None:
+    handlers = build_registry(policy=Policy.empty())
+    for path in ("security_model.nope", "getting_started.child", ".security_model"):
+        with pytest.raises(HandlerError) as exc:
+            await handlers["help"]({"path": path})
+        assert exc.value.code == "invalid_payload"
+
+
+@pytest.mark.asyncio
+async def test_help_progressive_rejects_bad_queries() -> None:
+    handlers = build_registry(policy=Policy.empty())
+    bad_payloads = [
+        {"topic": "security", "playbook": "x"},
+        {"topic": "security", "path": "security_model.sudo"},
+        {"topic": "does-not-exist"},
+        {"path": "security_model.sudo", "limit": 2},
+        {"surprise": True},
+        {"limit": 10},
+        {"topic": "security", "limit": 10},
+        {"playbook": "x", "offset": 0},
+        {"topic": "index", "limit": 0},
+        {"topic": "index", "limit": 101},
+        {"topic": "index", "offset": -1},
+        {"topic": "index", "limit": True},
+    ]
+    for payload in bad_payloads:
+        with pytest.raises(HandlerError) as exc:
+            await handlers["help"](payload)
+        assert exc.value.code == "invalid_payload"
+
+
+@pytest.mark.asyncio
+async def test_help_unknown_playbook_error_is_bounded() -> None:
+    p = Policy.from_dict(
+        {"playbooks": {f"playbook_{i:04d}": {"description": "x"} for i in range(500)}}
+    )
+    handlers = build_registry(policy=p)
+    with pytest.raises(HandlerError) as exc:
+        await handlers["help"]({"playbook": "missing"})
+    details = exc.value.details
+    assert details["available_playbooks"]["total"] == 500
+    assert len(details["available_playbooks"]["names"]) == 50
+    assert details["available_playbooks"]["truncated"] is True
+
+
+@pytest.mark.asyncio
+async def test_capabilities_summary_omits_policy_and_playbook_bodies() -> None:
+    p = Policy.from_dict(
+        {
+            "allowed_commands": ["ls", "cat"],
+            "services": {"nginx": {"actions": ["status"]}},
+            "playbooks": {"demo": {"description": "Demo", "steps": ["large body"]}},
+        }
+    )
+    handlers = build_registry(policy=p)
+    result = await handlers["capabilities"]({"detail": "summary"})
+    assert result["policy_summary"]["allowed_commands"] == 2
+    assert result["policy_summary"]["services"] == 1
+    assert result["policy_summary"]["playbooks"] == 1
+    assert "playbooks" not in result
+    assert "allowed_commands" not in result
+    assert "services" not in result
+    assert "locations" not in result
+    assert result["next"]["playbook"] == {
+        "backend_operation": "help",
+        "payload": {"playbook": "<name>"},
+    }
+    assert "playbook" in result["query_contract"]["help"]
+    assert result["query_contract"]["capabilities_detail"] == ["summary", "full"]
+
+
+@pytest.mark.asyncio
+async def test_capabilities_summary_size_does_not_scale_with_playbook_bodies() -> None:
+    p = Policy.from_dict(
+        {
+            "playbooks": {
+                f"playbook_{i:04d}": {"description": "x" * 1000, "steps": ["y" * 4000]}
+                for i in range(500)
+            }
+        }
+    )
+    handlers = build_registry(policy=p)
+    result = await handlers["capabilities"]({"detail": "summary"})
+    assert result["policy_summary"]["playbooks"] == 500
+    assert "playbooks" not in result
+
+
+@pytest.mark.asyncio
+async def test_capabilities_rejects_bad_projection_queries() -> None:
+    handlers = build_registry(policy=Policy.empty())
+    for payload in ({"detail": ""}, {"detail": "tiny"}, {"detail": 1}, {"detail": True}, {"x": 1}):
+        with pytest.raises(HandlerError) as exc:
+            await handlers["capabilities"](payload)
+        assert exc.value.code == "invalid_payload"
+
+
+@pytest.mark.asyncio
+async def test_capabilities_default_stays_full_for_compatibility() -> None:
+    p = Policy.from_dict({"allowed_commands": ["ls"]})
+    handlers = build_registry(policy=p)
+    result = await handlers["capabilities"]({})
+    assert result["allowed_commands"] == ["ls"]
+    assert "file_ops" in result
+    assert "introspection" not in result


### PR DESCRIPTION
## Summary

Implements the agent-side half of #20 by making the existing `help` / `capabilities` operations progressively queryable without changing their legacy empty-payload behavior.

The main goal is to keep compact-mode introspection from giving the context savings straight back, but the selectors are generic agent operations and can also be useful to full-profile or other clients.

### Progressive help

- `help({"topic":"index"})` — bounded topic + playbook-name index
- `help({"topic":"security"})` — one existing broad help section
- `help({"path":"security_model.permission_errors"})` — one exact leaf from the existing help tree
- `help({"playbook":"update_sentinelx_code"})` — one playbook only
- `help({"playbook":"update_sentinelx_code","path":"steps","offset":0,"limit":3})` — bounded playbook subfield
- `help({"topic":"playbooks","offset":...,"limit":...})` — paged playbook-name discovery
- `help({"topic":"all"})` — explicit legacy full response

Indexes and list-valued subpaths are bounded and return ready-to-route next-page requests. Unknown playbooks also return only a bounded catalog page rather than scaling the error with the whole policy.

### Profile-neutral scoped guidance

Stored playbooks currently use full-profile names such as `sentinel_exec` / `sentinel_service`. In the new *scoped* responses those textual references are normalized to `op:exec`, `op:service`, etc., with a small map recording the source names. The underlying policy/playbook text is not modified.

This is meant as one lightweight way to keep agent-side guidance usable through either full or compact presentation. **It is not intended to prescribe Hub architecture.** If you would rather have the Hub translate presentation names itself, the normalization is deliberately isolated to the new progressive responses and should be easy to replace/remove.

### Bounded capabilities

- `capabilities({"detail":"summary"})` returns host/version, supported ops, limits, policy counts, the small selector contract, and profile-neutral follow-up requests.
- It omits command/service/location values and playbook bodies/names.
- `capabilities({})` remains the existing full response.

The agent intentionally keeps empty-payload behavior backward-compatible. For compact mode, **one possible Hub-side choice** would be for the compact branches to default to `topic=index` / `detail=summary`; that seems like a clean separation because the Hub owns model-facing presentation. But that is just a suggestion — the selectors are optional and do not require that defaulting strategy.

## Compatibility

For the stock Linux, macOS, and Windows example policies, canonical JSON for both `help({})` and `capabilities({})` was compared with clean upstream `main` and matched exactly. Existing callers therefore keep the current full responses unless they opt into a selector.

## Context-size check

Representative serialized JSON sizes from local handler calls:

| Policy | Full help | Help index | Exact help leaf | Full capabilities | Capabilities summary |
|---|---:|---:|---:|---:|---:|
| Linux | 6438 | 1645 | 259 | 48212 | 1143 |
| macOS | 6359 | 1567 | 259 | 18016 | 1142 |
| Windows | 6277 | 1485 | 259 | 9307 | 1142 |

These are byte counts, not token estimates.

## Validation

A full review pass against the same upstream base produced:

- review branch: **150 passed, 1 failed**
- clean upstream `main`: **135 passed, 1 failed**

The same pre-existing `test_ops_supported_matches_registry` failure occurs on both because current upstream registers `project_snapshot` / `file_export_*` while the separate hand-maintained `ops_supported` list omits them. This PR does not fix or otherwise expand that unrelated issue.

Additional checks:

- Ruff check/format: pass on touched feature files
- compileall: pass
- wheel build: pass
- `git diff --check`: pass
- selector error/fuzz-ish matrix: 0 unexpected exceptions
- stock Linux/macOS/Windows policies exercised successfully
- 56 scoped topic/playbook guidance objects checked: 0 unnormalized `sentinel_*` names left in returned guidance bodies
- after the final design comments were added, a half-rigor pass (lint/format/compile + focused handler tests) passed: **8 passed**

## Hub side

No Hub schema change is included here. The Hub still needs to expose/pass the optional `topic`, `path`, `playbook`, `offset`, `limit`, and `detail` selectors through whichever full/compact schemas you want to support.
