### PR TITLE
Fix capabilities drift by deriving ops_supported from registry

### DIFF
--- a/src/sentinelx_core/handlers/__init__.py
+++ b/src/sentinelx_core/handlers/__init__.py
@@ -77,10 +77,17 @@ def build_registry(
 
     upload_base = policy.upload_base
 
-    return {
+    # Populated from the completed registry below, so capabilities has the
+    # exact same operation set without a second hand-maintained name list.
+    ops_supported: list[str] = []
+    registry: dict[str, Handler] = {
         # Read-only / introspection
         "ping": handle_ping,
-        "capabilities": make_capabilities_handler(policy, config_path),
+        "capabilities": make_capabilities_handler(
+            policy,
+            config_path,
+            ops_supported=ops_supported,
+        ),
         "help": make_help_handler(policy),
         "state": handle_state,
 
@@ -133,3 +140,5 @@ def build_registry(
         "chmod": make_chmod_handler(policy),
         "chown": make_chown_handler(policy),
     }
+    ops_supported.extend(registry)
+    return registry

--- a/src/sentinelx_core/handlers/basic.py
+++ b/src/sentinelx_core/handlers/basic.py
@@ -48,7 +48,12 @@ def make_read_audit_handler():
     return handle_read_audit
 
 
-def make_capabilities_handler(policy: Policy, config_path=None):
+def make_capabilities_handler(
+    policy: Policy,
+    config_path=None,
+    *,
+    ops_supported: list[str],
+):
     async def handle_capabilities(payload: dict[str, Any]) -> dict[str, Any]:
         """Return the policy as introspection data + ops supported.
 
@@ -78,24 +83,11 @@ def make_capabilities_handler(policy: Policy, config_path=None):
                 "kernel": platform.release(),
                 "arch": platform.machine(),
             },
-            # NOTE: keep this list in sync with build_registry() in
-            # handlers/__init__.py. It is intentionally explicit (not
-            # derived from the registry) so capabilities output is
-            # stable and readable, but that means new ops must be
-            # added in BOTH places. The five mutating ops below were
-            # added with the unified r/rw file-ops model.
-            "ops_supported": [
-                "ping", "capabilities", "help", "state",
-                "exec", "service", "restart",
-                "script_run",
-                "edit", "edit_upload_init", "edit_upload_file", "edit_upload_complete",
-                "upload_file", "upload_init", "upload_chunk", "upload_complete",
-                "read", "list", "search",
-                "read_audit",
-                "move", "copy", "delete", "chmod", "chown",
-                # Structured Git ops (sentinel_git) — see handlers/git_ops.py.
-                "git",
-            ],
+            # Registry membership is the single source of truth for operation
+            # discoverability. Keep the registry's insertion order so the
+            # capabilities payload remains deterministic/readable without a
+            # second hand-maintained operation list that can drift.
+            "ops_supported": list(ops_supported),
             "allowed_commands": list(policy.allowed_commands),
             "services": {
                 name: {

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -123,12 +123,10 @@ async def test_state_returns_host_info() -> None:
 
 @pytest.mark.asyncio
 async def test_ops_supported_matches_registry() -> None:
-    """`ops_supported` in capabilities is a hand-maintained list; it
-    MUST stay in sync with the actual op registry. This test is the
-    guard: it failed (and caught a real bug) when move/copy/delete/
-    chmod/chown were registered in build_registry but not added to the
-    capabilities list, so a client introspecting ops_supported
-    couldn't discover them. If you add an op, add it in BOTH places.
+    """Capabilities must advertise exactly the operations in the registry.
+
+    Registry membership is the source of truth: adding an operation must make
+    it discoverable without requiring a second hand-maintained name list.
     """
     handlers = build_registry(policy=Policy.empty())
     result = await handlers["capabilities"]({})
@@ -142,6 +140,28 @@ async def test_ops_supported_matches_registry() -> None:
     assert not phantom_in_caps, (
         f"ops advertised in capabilities but not registered: {sorted(phantom_in_caps)}"
     )
+    assert result["ops_supported"] == list(handlers), (
+        "ops_supported must preserve deterministic registry insertion order"
+    )
+
+    summary = await handlers["capabilities"]({"detail": "summary"})
+    assert summary["ops_supported"] == list(handlers), (
+        "summary capabilities must expose the same operation contract"
+    )
+
+
+@pytest.mark.asyncio
+async def test_capabilities_advertises_transfer_and_snapshot_ops() -> None:
+    """Regression for #32: newer registered ops remain discoverable."""
+    handlers = build_registry(policy=Policy.empty())
+    result = await handlers["capabilities"]({})
+    for op in (
+        "file_export_init",
+        "file_export_chunk",
+        "file_export_complete",
+        "project_snapshot",
+    ):
+        assert op in result["ops_supported"], f"{op!r} missing from ops_supported"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #32 by making the built handler registry the single source of truth for `capabilities.ops_supported` instead of maintaining a second hard-coded operation list.

The registry is completed first, its insertion-ordered keys are snapshotted into the capabilities handler, and both full and summary capabilities now advertise exactly the operations the agent can dispatch. This restores discovery of:

- `file_export_init`
- `file_export_chunk`
- `file_export_complete`
- `project_snapshot`

It also prevents the same drift from recurring when future operations are added.

## Tests

- pristine upstream reproduces the existing four-op failure in `test_ops_supported_matches_registry`
- full patched suite: **156 passed**
- full + summary capabilities exactly match the registry, including insertion order
- explicit regression coverage for the four #32 operations
- future-op mutation probe confirmed a newly registered operation is advertised without editing capabilities code
- repeated full-suite runs with different hash seeds passed
- Mypy on changed source: pass
- wheel + sdist isolated builds: pass
- built wheel installed into a fresh virtualenv and the full **156-test** suite passed
- fresh clone from upstream plus this exact commit passed the full suite

No runtime operation semantics are changed; this only makes introspection match the already-existing dispatch registry.
