### PR TITLE
fix: improve WebSocket liveness and reconnect recovery

### DIFF
--- a/src/sentinelx_core/client.py
+++ b/src/sentinelx_core/client.py
@@ -271,6 +271,7 @@ class HubClient:
         self._identity = identity
         self._executor = Executor(config_path=config_path)
         self._stop = asyncio.Event()
+        self._session_established = False
 
     async def run(self) -> None:
         """Main loop: connect, handle messages, reconnect on failure."""
@@ -285,6 +286,7 @@ class HubClient:
                 except asyncio.TimeoutError:
                     pass
 
+            self._session_established = False
             try:
                 await self._connect_and_serve()
                 attempt = 0  # reset on clean disconnect
@@ -302,17 +304,20 @@ class HubClient:
                     attempt = 0
                 else:
                     logger.warning("connection closed (%s): %s", exc.code, exc)
-                    attempt += 1
+                    attempt = 1 if self._session_established else attempt + 1
             except Exception as exc:  # noqa: BLE001
                 logger.warning("connection failed: %s", exc)
-                attempt += 1
+                attempt = 1 if self._session_established else attempt + 1
 
     async def _connect_and_serve(self) -> None:
         url = f"{self._ws_url}/agent/connect?token={self._identity.token}"
         logger.info("connecting to %s", self._ws_url)
 
         async with websockets.connect(
-            url, ping_interval=None, max_size=MAX_BINARY_FRAME_BYTES
+            url,
+            ping_interval=30,
+            ping_timeout=60,
+            max_size=MAX_BINARY_FRAME_BYTES,
         ) as ws:
             # 1. Send hello
             hello = HelloMessage(
@@ -343,6 +348,9 @@ class HubClient:
             if welcome.type != "welcome":  # type: ignore[union-attr]
                 raise RuntimeError(f"expected welcome, got {welcome.type}")  # type: ignore[union-attr]
 
+            # A valid welcome starts a new retry history. If this session later
+            # fails, the exception handler advances from zero to the first retry.
+            self._session_established = True
             logger.info("connected; session=%s", welcome.session_id)  # type: ignore[union-attr]
 
             # 3. Concurrent loops: read messages, send heartbeat

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,153 @@
+"""Focused tests for the WebSocket connection lifecycle."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import unittest
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+from sentinelx_protocol import HEARTBEAT_INTERVAL_SECONDS, MAX_BINARY_FRAME_BYTES, WelcomeMessage
+from websockets import frames
+from websockets.exceptions import ConnectionClosed
+
+from sentinelx_core.client import BACKOFF_SCHEDULE, HubClient
+
+
+class _ConnectionContext:
+    def __init__(self, websocket: AsyncMock) -> None:
+        self.websocket = websocket
+
+    async def __aenter__(self) -> AsyncMock:
+        return self.websocket
+
+    async def __aexit__(self, *_args: object) -> None:
+        return None
+
+
+class HubClientReconnectTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.client = object.__new__(HubClient)
+        self.client._stop = asyncio.Event()
+        self.client._session_established = False
+
+    async def _run_actions(self, actions: list[str]) -> list[float]:
+        remaining = list(actions)
+        delays: list[float] = []
+
+        async def connect_and_serve() -> None:
+            action = remaining.pop(0)
+            if action == "pre_welcome_failure":
+                raise OSError("connection failed before welcome")
+            if action == "established_1006":
+                self.client._session_established = True
+                raise ConnectionClosed(None, None)
+            if action == "established_1012":
+                self.client._session_established = True
+                raise ConnectionClosed(frames.Close(1012, "hub restart"), None)
+            if action == "stop":
+                self.client._stop.set()
+                return
+            raise AssertionError(f"unknown action: {action}")
+
+        async def record_wait(awaitable: object, timeout: float) -> None:
+            close = getattr(awaitable, "close", None)
+            if close is not None:
+                close()
+            delays.append(timeout)
+            raise TimeoutError
+
+        with (
+            patch.object(self.client, "_connect_and_serve", new=connect_and_serve),
+            patch("sentinelx_core.client.asyncio.wait_for", new=record_wait),
+        ):
+            await self.client.run()
+
+        self.assertEqual(remaining, [])
+        return delays
+
+    async def test_established_session_resets_old_backoff_before_1006(self) -> None:
+        delays = await self._run_actions(
+            ["pre_welcome_failure"] * 6 + ["established_1006", "stop"]
+        )
+
+        self.assertEqual(delays, BACKOFF_SCHEDULE[1:] + [1])
+
+    async def test_pre_welcome_failures_keep_escalating(self) -> None:
+        delays = await self._run_actions(["pre_welcome_failure"] * 7 + ["stop"])
+
+        self.assertEqual(delays, BACKOFF_SCHEDULE[1:] + [BACKOFF_SCHEDULE[-1]])
+
+    async def test_1012_remains_prompt_after_old_failures(self) -> None:
+        delays = await self._run_actions(
+            ["pre_welcome_failure"] * 6 + ["established_1012", "stop"]
+        )
+
+        self.assertEqual(delays, BACKOFF_SCHEDULE[1:])
+
+
+class HubClientKeepaliveTests(unittest.IsolatedAsyncioTestCase):
+    async def test_connect_enables_native_keepalive(self) -> None:
+        client = object.__new__(HubClient)
+        client._ws_url = "wss://hub.example"
+        client._identity = SimpleNamespace(token="test-token", host_id="host-test")
+        client._executor = SimpleNamespace(
+            config_summary=dict,
+            capability_names=list,
+            preferred_profile=lambda: None,
+        )
+        client._session_established = False
+
+        welcome = WelcomeMessage(
+            session_id="session-test",
+            server_time=datetime.now(UTC),
+        )
+        websocket = AsyncMock()
+        websocket.recv.return_value = welcome.model_dump_json()
+        connect = Mock(return_value=_ConnectionContext(websocket))
+
+        with (
+            patch("sentinelx_core.client.websockets.connect", new=connect),
+            patch.object(client, "_read_loop", new=AsyncMock(return_value=None)),
+            patch.object(client, "_heartbeat_loop", new=AsyncMock(return_value=None)),
+        ):
+            await client._connect_and_serve()
+
+        connect.assert_called_once_with(
+            "wss://hub.example/agent/connect?token=test-token",
+            ping_interval=30,
+            ping_timeout=60,
+            max_size=MAX_BINARY_FRAME_BYTES,
+        )
+        self.assertTrue(client._session_established)
+
+    async def test_application_ping_heartbeat_remains_active(self) -> None:
+        class EndHeartbeat(Exception):
+            pass
+
+        client = object.__new__(HubClient)
+        websocket = AsyncMock()
+        intervals: list[float] = []
+
+        async def sleep_then_stop(interval: float) -> None:
+            intervals.append(interval)
+            if len(intervals) > 1:
+                raise EndHeartbeat
+
+        with (
+            patch("sentinelx_core.client.asyncio.sleep", new=sleep_then_stop),
+            self.assertRaises(EndHeartbeat),
+        ):
+            await client._heartbeat_loop(websocket)
+
+        self.assertEqual(intervals, [HEARTBEAT_INTERVAL_SECONDS] * 2)
+        websocket.send.assert_awaited_once()
+        payload = json.loads(websocket.send.await_args.args[0])
+        self.assertEqual(payload["type"], "ping")
+        self.assertIn("timestamp", payload)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Improve SentinelX agent resilience when the Hub/WebSocket connection becomes half-open or terminates unexpectedly.

### Changes

- enable native WebSocket keepalive:
  - `ping_interval=30`
  - `ping_timeout=60`
- preserve the existing application-level `PingMessage` heartbeat
- reset reconnect backoff after a successful `welcome`
- after a healthy established session ends with `1006`, reconnect starts from the short retry interval instead of inheriting an old 30/60/120/300 second backoff
- failures before a successful `welcome` continue to escalate using the existing backoff schedule
- existing `1012` hub-restart behavior remains prompt

## Motivation

Observed production behavior included intermittent WebSocket `1006` disconnects and cases where the local TCP socket remained `ESTABLISHED` while the SentinelX Hub already considered the agent offline.

The agent currently disables the native `websockets` keepalive with `ping_interval=None`. Its application heartbeat sends messages but doesn't enforce a response deadline, so half-open connections may remain undetected.

Additionally, reconnect history wasn't reset after a successful `welcome`, allowing old failures to cause reconnect delays of up to 300 seconds even after long healthy sessions.

## Validation

Focused WebSocket tests with the production library version:

`websockets==17.0.1`

Result:

`5 passed`

Full patched suite:

`153 passed, 3 failed`

Pristine base SHA `e7284d579fc6e7de152716d7bd24c871dd499ce7` in the same environment:

`148 passed, 3 failed`

The same three tests fail on both pristine base and patched checkout, therefore:

`regressions caused by this patch: 0`

Additional validation:

- `compileall`: PASS
- `git diff --check`: PASS
- no new Ruff findings introduced in modified production code

No production deployment or service restart was performed.