### PR TITLE
Contain WebSocket connection task failures during teardown

### DIFF
--- a/src/sentinelx_core/client.py
+++ b/src/sentinelx_core/client.py
@@ -21,7 +21,6 @@ from typing import Any
 from uuid import uuid4
 
 import websockets
-from websockets.exceptions import ConnectionClosed
 from sentinelx_protocol import (
     HEARTBEAT_INTERVAL_SECONDS,
     MAX_BINARY_FRAME_BYTES,
@@ -37,6 +36,7 @@ from sentinelx_protocol import (
     is_binary_transfer_frame,
     parse_message,
 )
+from websockets.exceptions import ConnectionClosed
 
 from sentinelx_core import AGENT_VERSION
 from sentinelx_core.executor import Executor
@@ -272,6 +272,7 @@ class HubClient:
         self._executor = Executor(config_path=config_path)
         self._stop = asyncio.Event()
         self._session_established = False
+        self._background_tasks: set[asyncio.Task[Any]] = set()
 
     async def run(self) -> None:
         """Main loop: connect, handle messages, reconnect on failure."""
@@ -383,6 +384,9 @@ class HubClient:
                 for task in (read_task, heartbeat_task):
                     if not task.done():
                         task.cancel()
+                # Always await both connection-loop tasks so a simultaneous
+                # transport failure cannot leave an exception un-retrieved.
+                await asyncio.gather(read_task, heartbeat_task, return_exceptions=True)
 
     async def _read_loop(self, ws: websockets.WebSocketClientProtocol) -> None:
         async for raw in ws:
@@ -390,7 +394,7 @@ class HubClient:
             # chunks from the Hub) are raw bytes carrying the mini-framing
             # header; everything else is JSON control. See sentinelx_protocol.binary.
             if is_binary_transfer_frame(raw):
-                asyncio.create_task(self._handle_binary_frame(ws, raw))
+                self._spawn_background_task(self._handle_binary_frame(ws, raw))
                 continue
             try:
                 data = json.loads(raw) if isinstance(raw, str) else json.loads(raw.decode())
@@ -401,7 +405,7 @@ class HubClient:
 
             if msg.type == "request":  # type: ignore[union-attr]
                 # Handle in background so a slow op doesn't block the read loop
-                asyncio.create_task(self._handle_request(ws, msg))
+                self._spawn_background_task(self._handle_request(ws, msg))
             elif msg.type == "ping":  # type: ignore[union-attr]
                 await ws.send(
                     PongMessage(timestamp=datetime.now(timezone.utc)).model_dump_json()
@@ -438,7 +442,7 @@ class HubClient:
             },
         }
         await ws.send(json.dumps(ack, default=str))
-        asyncio.create_task(
+        self._spawn_background_task(
             self._run_job_and_report(ws, request, job_id, started_at)
         )
 
@@ -566,6 +570,38 @@ class HubClient:
             ).model_dump_json())
         except Exception:  # noqa: BLE001
             pass
+
+    def _spawn_background_task(self, awaitable: Any) -> asyncio.Task[Any]:
+        """Retain fire-and-forget work and deterministically consume failures.
+
+        Foreground request execution is deliberately not cancelled when a
+        connection closes: the operation may already have crossed a mutation
+        boundary and existing request replay/idempotency remains authoritative.
+        The task is retained until completion so Python never reports an orphaned
+        exception if response delivery later fails on the old WebSocket.
+        """
+        task = asyncio.create_task(awaitable)
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_task_done)
+        return task
+
+    def _background_task_done(self, task: asyncio.Task[Any]) -> None:
+        self._background_tasks.discard(task)
+        if task.cancelled():
+            return
+        try:
+            exc = task.exception()
+        except asyncio.CancelledError:
+            return
+        if exc is None:
+            return
+        if isinstance(exc, ConnectionClosed):
+            logger.debug("background task ended after WebSocket close: %s", exc)
+        else:
+            logger.error(
+                "background client task failed",
+                exc_info=(type(exc), exc, exc.__traceback__),
+            )
 
     async def _heartbeat_loop(self, ws: websockets.WebSocketClientProtocol) -> None:
         from sentinelx_protocol import PingMessage

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -32,6 +32,7 @@ class HubClientReconnectTests(unittest.IsolatedAsyncioTestCase):
         self.client = object.__new__(HubClient)
         self.client._stop = asyncio.Event()
         self.client._session_established = False
+        self.client._background_tasks = set()
 
     async def _run_actions(self, actions: list[str]) -> list[float]:
         remaining = list(actions)
@@ -99,6 +100,7 @@ class HubClientKeepaliveTests(unittest.IsolatedAsyncioTestCase):
             preferred_profile=lambda: None,
         )
         client._session_established = False
+        client._background_tasks = set()
 
         welcome = WelcomeMessage(
             session_id="session-test",
@@ -153,6 +155,76 @@ class HubClientKeepaliveTests(unittest.IsolatedAsyncioTestCase):
         payload = json.loads(websocket.send.await_args.args[0])
         self.assertEqual(payload["type"], "ping")
         self.assertIn("timestamp", payload)
+
+
+class HubClientTaskLifecycleTests(unittest.IsolatedAsyncioTestCase):
+    async def test_background_request_close_is_retained_and_consumed(self) -> None:
+        client = object.__new__(HubClient)
+        client._background_tasks = set()
+        client._executor = SimpleNamespace(
+            dispatch=AsyncMock(return_value={"ok": True, "result": {}})
+        )
+        websocket = AsyncMock()
+        websocket.send.side_effect = ConnectionClosed(None, None)
+        request = SimpleNamespace(id="req-1", op="state", payload={})
+        loop = asyncio.get_running_loop()
+        contexts: list[dict[str, object]] = []
+        old_handler = loop.get_exception_handler()
+        loop.set_exception_handler(lambda _loop, context: contexts.append(context))
+        try:
+            task = client._spawn_background_task(
+                client._handle_request(websocket, request)
+            )
+            await asyncio.wait({task})
+            await asyncio.sleep(0)
+        finally:
+            loop.set_exception_handler(old_handler)
+        self.assertEqual(client._background_tasks, set())
+        self.assertEqual(contexts, [])
+
+    async def test_connect_teardown_retrieves_both_loop_failures(self) -> None:
+        client = object.__new__(HubClient)
+        client._ws_url = "wss://hub.example"
+        client._identity = SimpleNamespace(token="test-token", host_id="host-test")
+        client._executor = SimpleNamespace(
+            config_summary=dict,
+            capability_names=list,
+            preferred_profile=lambda: None,
+        )
+        client._session_established = False
+        client._background_tasks = set()
+        welcome = WelcomeMessage(
+            session_id="session-test",
+            server_time=datetime.now(UTC),
+        )
+        websocket = AsyncMock()
+        websocket.recv.return_value = welcome.model_dump_json()
+        connect = Mock(return_value=_ConnectionContext(websocket))
+        gate = asyncio.Event()
+
+        async def fail_loop(_ws: object) -> None:
+            await gate.wait()
+            raise ConnectionClosed(None, None)
+
+        loop = asyncio.get_running_loop()
+        contexts: list[dict[str, object]] = []
+        old_handler = loop.get_exception_handler()
+        loop.set_exception_handler(lambda _loop, context: contexts.append(context))
+        try:
+            with (
+                patch("sentinelx_core.client.websockets.connect", new=connect),
+                patch.object(client, "_read_loop", new=fail_loop),
+                patch.object(client, "_heartbeat_loop", new=fail_loop),
+            ):
+                runner = asyncio.create_task(client._connect_and_serve())
+                await asyncio.sleep(0)
+                gate.set()
+                with self.assertRaises(ConnectionClosed):
+                    await runner
+                await asyncio.sleep(0)
+        finally:
+            loop.set_exception_handler(old_handler)
+        self.assertEqual(contexts, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes the WebSocket connection-task lifecycle bug described in #42.

Connection-scoped request/binary/background tasks are retained until completion and their exceptions are deterministically consumed. Expected `ConnectionClosed` failures during old-socket delivery are treated as transport teardown, while unexpected exceptions remain logged.

The top-level read/heartbeat tasks are also always gathered with `return_exceptions=True` during teardown so simultaneous close failures cannot escape as `Task exception was never retrieved`.

Importantly, an in-flight foreground operation is **not** cancelled merely because its response WebSocket closes. It may already have crossed a mutation boundary, so the existing idempotency/replay contract remains authoritative.

## Regression coverage

Adds coverage for:

- foreground response delivery failing with `ConnectionClosed` while the retained task set drains cleanly;
- simultaneous read-loop and heartbeat-loop connection failures with both exceptions retrieved;
- no orphaned asyncio task exception context during these teardown paths.

## Validation

Validated against the exact 0.11.14 reproduction base (`d6b33822b61e7fccf39547d5cce8add8bc7021f9`):

- `230 passed, 3 warnings`
- `compileall`: PASS
- `git diff --check`: PASS
- Ruff comparison using the same Ruff build:
  - pristine upstream client/tests: 45 findings
  - patched client/tests: 44 findings
  - no new Ruff findings introduced

The running SentinelX agent was not modified during patch validation.

Closes #42.
